### PR TITLE
Update JDK base image to eclipse-temurin:17-jdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jdk 
 
 WORKDIR /app
 


### PR DESCRIPTION
### What’s this PR do?
Updates base docker JDK image to eclipse:temurin-17-jdk

### Related Issue
Closes #17 
